### PR TITLE
Fix CardAgent tool return types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,16 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.11.0</version>
+        <configuration>
+          <compilerArgs>
+            <arg>-parameters</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
       <!-- Plugin para executar a aplicação -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/src/main/java/com/example/adk/cards/card/CardAgent.java
+++ b/src/main/java/com/example/adk/cards/card/CardAgent.java
@@ -44,30 +44,46 @@ public class CardAgent {
     }
 
     @Annotations.Schema(description = "Bloqueia um cartão")
-    public static ApiResponse<String> block(
+    public static java.util.Map<String, Object> block(
             @Annotations.Schema(description = "UUID do cartão") String uuid
     ) {
-        return SERVICE.block(uuid);
+        ApiResponse<String> response = SERVICE.block(uuid);
+        return java.util.Map.of(
+                "status", response.getStatus(),
+                "body", response.getBody(),
+                "message", response.getMessage());
     }
 
     @Annotations.Schema(description = "Desbloqueia um cartão")
-    public static ApiResponse<String> unblock(
+    public static java.util.Map<String, Object> unblock(
             @Annotations.Schema(description = "UUID do cartão") String uuid
     ) {
-        return SERVICE.unblock(uuid);
+        ApiResponse<String> response = SERVICE.unblock(uuid);
+        return java.util.Map.of(
+                "status", response.getStatus(),
+                "body", response.getBody(),
+                "message", response.getMessage());
     }
 
     @Annotations.Schema(description = "Consulta dados de um cartão")
-    public static ApiResponse<CardDto> get(
+    public static java.util.Map<String, Object> get(
             @Annotations.Schema(description = "UUID do cartão") String uuid
     ) {
-        return SERVICE.get(uuid);
+        ApiResponse<CardDto> response = SERVICE.get(uuid);
+        return java.util.Map.of(
+                "status", response.getStatus(),
+                "body", response.getBody(),
+                "message", response.getMessage());
     }
 
     @Annotations.Schema(description = "Cancela um cartão")
-    public static ApiResponse<String> cancel(
+    public static java.util.Map<String, Object> cancel(
             @Annotations.Schema(description = "Payload para cancelar cartão") CancelCardDto dto
     ) {
-        return SERVICE.cancel(dto);
+        ApiResponse<String> response = SERVICE.cancel(dto);
+        return java.util.Map.of(
+                "status", response.getStatus(),
+                "body", response.getBody(),
+                "message", response.getMessage());
     }
 }


### PR DESCRIPTION
## Summary
- convert CardAgent tool methods to return `Map` objects instead of `ApiResponse`
- enable `-parameters` compiler flag via `maven-compiler-plugin`

## Testing
- `mvn -e -DskipTests org.codehaus.mojo:exec-maven-plugin:3.1.0:java` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_6844d368c4e4832d8566ed71601829b9